### PR TITLE
Allow opening at the latest version

### DIFF
--- a/tests/js.rs
+++ b/tests/js.rs
@@ -44,6 +44,11 @@ async fn smoke_test() {
         .await
         .unwrap_err();
 
+    // Factory::open_latest_version
+    let db = factory.open_latest_version("foo").await.unwrap();
+    assert_eq!(db.name(), "foo");
+    assert_eq!(db.version(), 2);
+
     // Database::build_object_store
     let db = factory
         .open("bar", 1, |evt| async move {


### PR DESCRIPTION
This allows passing a `None` version when opening the db, resulting in a `web_sys::IdbFactory::open()` call that opens the db with the latest version. This is needed when data is persisted across sessions and the latest version is unknown.