### PR TITLE
Use async closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Ekleog/indexed-db"
 keywords = ["wasm", "indexeddb", "async", "web", "webassembly"]
 categories = ["asynchronous", "database", "wasm", "web-programming"]
+rust-version = "1.85"
 
 [dependencies]
 futures-channel = "0.3.30"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ async fn example() -> anyhow::Result<()> {
 
     // Open the database, creating it if needed
     let db = factory
-        .open("database", 1, |evt| async move {
+        .open("database", 1, async move |evt| {
             let db = evt.database();
             let store = db.build_object_store("store").auto_increment().create()?;
 
@@ -48,7 +48,7 @@ async fn example() -> anyhow::Result<()> {
     // In a transaction, add two records
     db.transaction(&["store"])
         .rw()
-        .run(|t| async move {
+        .run(async move |t| {
             let store = t.object_store("store")?;
             store.add(&JsString::from("bar")).await?;
             store.add(&JsString::from("baz")).await?;
@@ -58,7 +58,7 @@ async fn example() -> anyhow::Result<()> {
 
     // In another transaction, read the first record
     db.transaction(&["store"])
-        .run(|t| async move {
+        .run(async move |t| {
             let data = t.object_store("store")?.get_all(Some(1)).await?;
             if data.len() != 1 {
                 Err(std::io::Error::new(
@@ -73,7 +73,7 @@ async fn example() -> anyhow::Result<()> {
     // If we return `Err` (or panic) from a transaction, then it will abort
     db.transaction(&["store"])
         .rw()
-        .run(|t| async move {
+        .run(async move |t| {
             let store = t.object_store("store")?;
             store.add(&JsString::from("quux")).await?;
             if store.count().await? > 3 {
@@ -90,7 +90,7 @@ async fn example() -> anyhow::Result<()> {
 
     // And no write will have happened
     db.transaction(&["store"])
-        .run(|t| async move {
+        .run(async move |t| {
             let num_items = t.object_store("store")?.count().await?;
             assert_eq!(num_items, 3);
             Ok(())
@@ -99,7 +99,7 @@ async fn example() -> anyhow::Result<()> {
 
     // More complex example: using cursors to iterate over a store
     db.transaction(&["store"])
-        .run(|t| async move {
+        .run(async move |t| {
             let mut all_items = Vec::new();
             let mut cursor = t.object_store("store")?.cursor().open().await?;
             while let Some(value) = cursor.value() {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -101,7 +101,7 @@ impl<Err: 'static> Factory<Err> {
         &self,
         name: &str,
         version: u32,
-        on_upgrade_needed: impl AsyncFnOnce(VersionChangeEvent<Err>) -> crate::Result<(), Err> + 'static,
+        on_upgrade_needed: impl 'static + AsyncFnOnce(VersionChangeEvent<Err>) -> crate::Result<(), Err>,
     ) -> crate::Result<Database<Err>, Err> {
         if version == 0 {
             return Err(crate::Error::VersionMustNotBeZero);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -98,11 +98,12 @@ impl<Err> TransactionBuilder<Err> {
     // - If the `Closure` from `transaction_request` has already been dropped, then the callback
     //   will panic. Most likely this will lead to the transaction aborting, but this is an
     //   untested and unsupported code path.
-    pub async fn run<Ret: 'static>(
+    pub async fn run<Ret>(
         self,
-        transaction: impl AsyncFnOnce(Transaction<Err>) -> crate::Result<Ret, Err> + 'static,
+        transaction: impl 'static + AsyncFnOnce(Transaction<Err>) -> crate::Result<Ret, Err>,
     ) -> crate::Result<Ret, Err>
     where
+        Ret: 'static,
         Err: 'static,
     {
         let t = self

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use futures_channel::oneshot;
 use futures_util::future::{self, Either};
-use std::{future::Future, marker::PhantomData};
+use std::marker::PhantomData;
 use web_sys::{
     wasm_bindgen::{JsCast, JsValue},
     IdbDatabase, IdbRequest, IdbTransaction, IdbTransactionMode,
@@ -98,11 +98,11 @@ impl<Err> TransactionBuilder<Err> {
     // - If the `Closure` from `transaction_request` has already been dropped, then the callback
     //   will panic. Most likely this will lead to the transaction aborting, but this is an
     //   untested and unsupported code path.
-    pub async fn run<Fun, RetFut, Ret>(self, transaction: Fun) -> crate::Result<Ret, Err>
+    pub async fn run<Ret: 'static>(
+        self,
+        transaction: impl AsyncFnOnce(Transaction<Err>) -> crate::Result<Ret, Err> + 'static,
+    ) -> crate::Result<Ret, Err>
     where
-        Fun: 'static + FnOnce(Transaction<Err>) -> RetFut,
-        RetFut: 'static + Future<Output = crate::Result<Ret, Err>>,
-        Ret: 'static,
         Err: 'static,
     {
         let t = self

--- a/tests/common_panic/mod.rs
+++ b/tests/common_panic/mod.rs
@@ -17,7 +17,7 @@ async fn other_awaits_panic() {
     let factory = Factory::<anyhow::Error>::get().unwrap();
 
     let db = factory
-        .open("baz", 1, |evt| async move {
+        .open("baz", 1, async move |evt| {
             let db = evt.database();
             db.build_object_store("data").auto_increment().create()?;
             Ok(())
@@ -29,7 +29,7 @@ async fn other_awaits_panic() {
 
     db.transaction(&["data"])
         .rw()
-        .run(|t| async move {
+        .run(async move |t| {
             t.object_store("data")?.add(&JsString::from("foo")).await?;
             rx.await.context("awaiting for something external")?;
             t.object_store("data")?.add(&JsString::from("bar")).await?;
@@ -52,7 +52,7 @@ async fn await_in_versionchange_panics() {
     let (tx, rx) = futures_channel::oneshot::channel();
 
     factory
-        .open("baz", 1, |evt| async move {
+        .open("baz", 1, async move |evt| {
             let db = evt.database();
             db.build_object_store("data").auto_increment().create()?;
             rx.await.context("awaiting for something external")?;


### PR DESCRIPTION
close #5 

Note this constitutes a breaking change, and means only Rust>=1.85 is supported

Regarding the Rust>=1.85, another solution to avoid this would be to put async closure support under a feature.
This is a bit trick though: since `Faction::open` & `TransactionBuilder::run` would have two flavors of signature.

To do that there is basically three ways:
1. Duplicate `Faction::open` & `TransactionBuilder::run` bodies
2. Put `Faction::open` & `TransactionBuilder::run` body inside a macro which is called in each flavor of the functions
3. Have the async-closure flavor of `Faction::open` & `TransactionBuilder::run` internally calles the sync-closure -returning-future

```rust
    #[cfg(not(feature = "async-closure"))]
    pub async fn open<Fun, RetFut>(
        &self,
        name: &str,
        version: u32,
        on_upgrade_needed: Fun,
    ) -> crate::Result<Database<Err>, Err>
    where
        Fun: 'static + FnOnce(VersionChangeEvent<Err>) -> RetFut,
        RetFut: 'static + Future<Output = crate::Result<(), Err>> {
        self.open_internal(name, version, on_upgrade_needed).await
}

    #[cfg(feature = "async-closure")]
    pub async fn open(
        &self,
        name: &str,
        version: u32,
        on_upgrade_needed: impl AsyncFnOnce(VersionChangeEvent<Err>) -> crate::Result<(), Err> + 'static,
    ) -> crate::Result<Database<Err>, Err> {
        self.open_internal(name, version, |evt| on_upgrade_needed(evt)).await
    }

    async fn open_internal<Fun, RetFut>(
        &self,
        name: &str,
        version: u32,
        on_upgrade_needed: Fun,
    ) -> crate::Result<Database<Err>, Err>
    where
        Fun: 'static + FnOnce(VersionChangeEvent<Err>) -> RetFut,
        RetFut: 'static + Future<Output = crate::Result<(), Err>> {
        ...
    }
```

Solution 3 seems the most elegant, however it only works because the async closure is `'static`.

If that wasn't the case we would in theory need to use a `unsafe std::mem::transmute` to overwrite the lifetime of the async closure before passing it to `open_internal`... but even this doesn't work in practice:
- In Rust each closure has it own type (i.e. two closures with the same signature are considered of different types), so turning a `impl AsyncFnOnce()` into a `impl AsyncFnOnce() + 'static` cannot be expressed as far as I'm aware (as there is no way in telling the resulting `impl AsyncFnOnce() + 'static` have the same size than the `impl AsyncFnOnce()` provided as input)
- On top of that `unsafe_jar::run` relies on `wasm_bindgen::Closure::once` which itself requires the passed closure to be `'static`