### PR TITLE
relax lifetime requirements for transaction

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,4 +1,4 @@
-use crate::{transaction::runner, utils::generic_request, Database, Transaction};
+use crate::{transaction::unsafe_jar, utils::generic_request, Database, Transaction};
 use futures_channel::oneshot;
 use futures_util::{pin_mut, FutureExt};
 use std::{cell::Cell, marker::PhantomData, rc::Rc};
@@ -121,7 +121,7 @@ impl<Err: 'static> Factory<Err> {
                 ran_upgrade_cb_clone.set(true);
                 on_upgrade_needed(evt).await
             };
-            runner::run(runner::RunnableTransaction::new(
+            unsafe_jar::run(unsafe_jar::RunnableTransaction::new(
                 transaction,
                 fut,
                 upgrade_res_tx,

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,5 +1,5 @@
 use crate::{
-    transaction::unsafe_jar::{self, extend_lifetime_to_scope_and_run},
+    transaction::unsafe_jar,
     utils::{generic_request, str_slice_to_array},
     Database, ObjectStore, Transaction,
 };
@@ -115,7 +115,7 @@ impl Factory {
         let ran_upgrade_cb = Cell::new(false);
         let ran_upgrade_cb = &ran_upgrade_cb;
 
-        extend_lifetime_to_scope_and_run(Box::new(move |(transaction, event): (IdbTransaction, VersionChangeEvent<Err>)| {
+        unsafe_jar::extend_lifetime_to_scope_and_run(Box::new(move |(transaction, event): (IdbTransaction, VersionChangeEvent<Err>)| {
             let fut = async move {
                 ran_upgrade_cb.set(true);
                 on_upgrade_needed(event).await

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,5 +1,5 @@
 use crate::{
-    transaction::unsafe_jar,
+    transaction::{unsafe_jar, RunnableTransaction, TransactionResult},
     utils::{non_transaction_request, str_slice_to_array},
     Database, ObjectStore, OwnedDatabase, Transaction,
 };
@@ -126,7 +126,7 @@ impl Factory {
                         ran_upgrade_cb.set(true);
                         on_upgrade_needed(event).await
                     };
-                    unsafe_jar::RunnableTransaction::new(transaction, fut, result, finished_tx)
+                    RunnableTransaction::new(transaction, fut, result, finished_tx)
                 },
             ),
             async move |s| {
@@ -149,10 +149,10 @@ impl Factory {
                         .take()
                         .expect("Finished was called without the result being available");
                     match result {
-                        unsafe_jar::TransactionResult::PolledForbiddenThing => {
+                        TransactionResult::PolledForbiddenThing => {
                             panic!("Transaction blocked without any request under way")
                         }
-                        unsafe_jar::TransactionResult::Done(upgrade_res) => upgrade_res?,
+                        TransactionResult::Done(upgrade_res) => upgrade_res?,
                     }
                 }
                 completion_res.map_err(crate::Error::from_js_event)?;

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,6 +1,6 @@
 use crate::{
     transaction::unsafe_jar,
-    utils::{generic_request, str_slice_to_array},
+    utils::{non_transaction_request, str_slice_to_array},
     Database, ObjectStore, Transaction,
 };
 use futures_util::{pin_mut, FutureExt};
@@ -76,7 +76,7 @@ impl Factory {
     ///
     /// This internally uses [`IDBFactory::deleteDatabase`](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/deleteDatabase)
     pub async fn delete_database(&self, name: &str) -> crate::Result<(), Infallible> {
-        generic_request(
+        non_transaction_request(
             self.sys
                 .delete_database(name)
                 .map_err(crate::Error::from_js_value)?
@@ -140,7 +140,7 @@ impl Factory {
                     on_upgrade_needed.as_ref().dyn_ref::<Function>().unwrap(),
                 ));
 
-                let completion_res = generic_request(open_req.clone().into()).await;
+                let completion_res = non_transaction_request(open_req.clone().into()).await;
                 if ran_upgrade_cb.get() {
                     // The upgrade callback was run, so we need to wait for its result to reach us
                     let _ = finished_rx.await;
@@ -179,7 +179,7 @@ impl Factory {
     pub async fn open_latest_version(&self, name: &str) -> crate::Result<Database, Infallible> {
         let open_req = self.sys.open(name).map_err(crate::Error::from_js_value)?;
 
-        let completion_fut = generic_request(open_req.clone().into())
+        let completion_fut = non_transaction_request(open_req.clone().into())
             .map(|res| res.map_err(crate::Error::from_js_event));
         pin_mut!(completion_fut);
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -3,9 +3,12 @@ use crate::{
     utils::{generic_request, str_slice_to_array},
     Database, ObjectStore, Transaction,
 };
-use futures_channel::oneshot;
 use futures_util::{pin_mut, FutureExt};
-use std::{cell::Cell, convert::Infallible, marker::PhantomData};
+use std::{
+    cell::{Cell, RefCell},
+    convert::Infallible,
+    marker::PhantomData,
+};
 use web_sys::{
     js_sys::{self, Function, JsString},
     wasm_bindgen::{closure::Closure, JsCast, JsValue},
@@ -110,54 +113,60 @@ impl Factory {
             .open_with_u32(name, version)
             .map_err(crate::Error::from_js_value)?;
 
-        let (upgrade_res_tx, mut upgrade_res_rx) = oneshot::channel();
-        let (polled_forbidden_thing_tx, mut polled_forbidden_thing_rx) = oneshot::channel();
+        let result = RefCell::new(None);
+        let result = &result;
+        let (finished_tx, finished_rx) = futures_channel::oneshot::channel();
         let ran_upgrade_cb = Cell::new(false);
         let ran_upgrade_cb = &ran_upgrade_cb;
 
-        unsafe_jar::extend_lifetime_to_scope_and_run(Box::new(move |(transaction, event): (IdbTransaction, VersionChangeEvent<Err>)| {
-            let fut = async move {
-                ran_upgrade_cb.set(true);
-                on_upgrade_needed(event).await
-            };
-            unsafe_jar::RunnableTransaction::new(
-                transaction,
-                fut,
-                upgrade_res_tx,
-                polled_forbidden_thing_tx,
-            )
-        }), async move |s| {
-            // Separate variable to keep the closure alive until opening completed
-            let on_upgrade_needed = Closure::once(move |evt: IdbVersionChangeEvent| {
-                let evt = VersionChangeEvent::from_sys(evt);
-                let transaction = evt.transaction().as_sys().clone();
-                s.run((transaction, evt))
-            });
-            open_req.set_onupgradeneeded(Some(
-                on_upgrade_needed.as_ref().dyn_ref::<Function>().unwrap(),
-            ));
+        unsafe_jar::extend_lifetime_to_scope_and_run(
+            Box::new(
+                move |(transaction, event): (IdbTransaction, VersionChangeEvent<Err>)| {
+                    let fut = async move {
+                        ran_upgrade_cb.set(true);
+                        on_upgrade_needed(event).await
+                    };
+                    unsafe_jar::RunnableTransaction::new(transaction, fut, result, finished_tx)
+                },
+            ),
+            async move |s| {
+                // Separate variable to keep the closure alive until opening completed
+                let on_upgrade_needed = Closure::once(move |evt: IdbVersionChangeEvent| {
+                    let evt = VersionChangeEvent::from_sys(evt);
+                    let transaction = evt.transaction().as_sys().clone();
+                    s.run((transaction, evt))
+                });
+                open_req.set_onupgradeneeded(Some(
+                    on_upgrade_needed.as_ref().dyn_ref::<Function>().unwrap(),
+                ));
 
-            let completion_res = generic_request(open_req.clone().into()).await;
-            if ran_upgrade_cb.get() {
-                // The upgrade callback was run, so we need to wait for its result to reach us
-                futures_util::select! {
-                    upgrade_res = upgrade_res_rx => {
-                        let upgrade_res = upgrade_res.expect("Closure dropped before its end of scope");
-                        upgrade_res?;
-                    },
-                    _ = polled_forbidden_thing_rx => panic!("Transaction blocked without any request under way"),
+                let completion_res = generic_request(open_req.clone().into()).await;
+                if ran_upgrade_cb.get() {
+                    // The upgrade callback was run, so we need to wait for its result to reach us
+                    let _ = finished_rx.await;
+                    let result = result
+                        .borrow_mut()
+                        .take()
+                        .expect("Finished was called without the result being available");
+                    match result {
+                        unsafe_jar::TransactionResult::PolledForbiddenThing => {
+                            panic!("Transaction blocked without any request under way")
+                        }
+                        unsafe_jar::TransactionResult::Done(upgrade_res) => upgrade_res?,
+                    }
                 }
-            }
-            completion_res.map_err(crate::Error::from_js_event)?;
+                completion_res.map_err(crate::Error::from_js_event)?;
 
-            let db = open_req
-                .result()
-                .map_err(crate::Error::from_js_value)?
-                .dyn_into::<IdbDatabase>()
-                .expect("Result of successful IDBOpenDBRequest is not an IDBDatabase");
+                let db = open_req
+                    .result()
+                    .map_err(crate::Error::from_js_value)?
+                    .dyn_into::<IdbDatabase>()
+                    .expect("Result of successful IDBOpenDBRequest is not an IDBDatabase");
 
-            Ok(Database::from_sys(db))
-        }).await
+                Ok(Database::from_sys(db))
+            },
+        )
+        .await
     }
 
     /// Open a database at the latest version

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -168,8 +168,6 @@ impl<'a, T> Future for FakeFuture<'a, T> {
 }
 
 pub(crate) async fn transaction_request(req: IdbRequest) -> Result<JsValue, JsValue> {
-    // TODO: our custom-made channel will not call the waker (because we're handling wakes another way),
-    // so we can use a panicking context again.
     let result = Rc::new(RefCell::new(None));
 
     // Keep the callbacks alive until execution completed

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,8 +2,14 @@ use crate::{
     utils::{err_from_event, str_slice_to_array},
     ObjectStore,
 };
-use futures_channel::oneshot;
-use std::{cell::RefCell, marker::PhantomData};
+use std::{
+    cell::RefCell,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll},
+};
 use web_sys::{
     wasm_bindgen::{JsCast, JsValue},
     IdbDatabase, IdbRequest, IdbTransaction, IdbTransactionMode,
@@ -139,22 +145,39 @@ impl TransactionBuilder {
     }
 }
 
+struct FakeFuture<'a, T> {
+    watching: &'a RefCell<Option<T>>,
+}
+
+impl<'a, T> FakeFuture<'a, T> {
+    fn new(watching: &'a RefCell<Option<T>>) -> FakeFuture<'a, T> {
+        FakeFuture { watching }
+    }
+}
+
+impl<'a, T> Future for FakeFuture<'a, T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<T> {
+        // Don't do this at home! This only works thanks to our unsafe jar polling regardless of the waker
+        match self.watching.borrow_mut().take() {
+            None => Poll::Pending,
+            Some(r) => Poll::Ready(r),
+        }
+    }
+}
+
 pub(crate) async fn transaction_request(req: IdbRequest) -> Result<JsValue, JsValue> {
-    // TODO: remove these oneshot-channel in favor of a custom-made atomiccell-based channel.
-    // the custom-made channel will not call the waker (because we're handling wakes another way),
-    // which'll allow using a panicking context again.
-    // The custom channel can just be a Mutex<Either<Pending, Ready<T>>>, where fulfilling it switches
-    // the contained future between pending and ready.
-    let (success_tx, mut success_rx) = oneshot::channel();
-    let (error_tx, mut error_rx) = oneshot::channel();
+    // TODO: our custom-made channel will not call the waker (because we're handling wakes another way),
+    // so we can use a panicking context again.
+    let result = Rc::new(RefCell::new(None));
 
     // Keep the callbacks alive until execution completed
     // This also means that the tx's will not be dropped, hence the below unwraps
-    let _callbacks = unsafe_jar::add_request(req, success_tx, error_tx);
+    let _callbacks = unsafe_jar::add_request(req, &result);
 
-    futures_util::select! {
-        success_res = success_rx => {
-            let evt = success_res.unwrap();
+    match FakeFuture::new(&result).await {
+        Ok(evt) => {
             let result = evt.target()
                 .expect("Trying to parse indexed_db::Error from an event that has no target")
                 .dyn_into::<web_sys::IdbRequest>()
@@ -163,6 +186,6 @@ pub(crate) async fn transaction_request(req: IdbRequest) -> Result<JsValue, JsVa
                 .expect("Failed retrieving the result of successful IDBRequest");
             Ok(result)
         }
-        error_res = error_rx => Err(err_from_event(error_res.unwrap()).into()),
+        Err(evt) => Err(err_from_event(evt).into()),
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -113,20 +113,19 @@ impl<Err> TransactionBuilder<Err> {
         let (result_tx, mut result_rx) = futures_channel::oneshot::channel();
         let (polled_forbidden_thing_tx, mut polled_forbidden_thing_rx) =
             futures_channel::oneshot::channel();
-        unsafe_jar::extend_lifetime_and_run(
-            unsafe_jar::RunnableTransaction::new(
+        unsafe_jar::extend_lifetime_to_scope_and_run(async move |mut s| {
+            s.set_maker(Box::new(move |()| unsafe_jar::RunnableTransaction::new(
                 t.clone(),
                 transaction(Transaction::from_sys(t)),
                 result_tx,
                 polled_forbidden_thing_tx,
-            ),
-            async move || {
-                futures_util::select! {
-                    res = result_rx => res.expect("Transaction never completed"),
-                    _ = polled_forbidden_thing_rx => panic!("Transaction blocked without any request under way"),
-                }
-            },
-        ).await
+            )));
+            s.run(());
+            futures_util::select! {
+                res = result_rx => res.expect("Transaction never completed"),
+                _ = polled_forbidden_thing_rx => panic!("Transaction blocked without any request under way"),
+            }
+        }).await
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -173,7 +173,6 @@ pub(crate) async fn transaction_request(req: IdbRequest) -> Result<JsValue, JsVa
     let result = Rc::new(RefCell::new(None));
 
     // Keep the callbacks alive until execution completed
-    // This also means that the tx's will not be dropped, hence the below unwraps
     let _callbacks = unsafe_jar::add_request(req, &result);
 
     match FakeFuture::new(&result).await {

--- a/src/transaction/runner.rs
+++ b/src/transaction/runner.rs
@@ -1,0 +1,180 @@
+//! All the required to run a transaction
+
+use std::{
+    cell::{Cell, RefCell},
+    future::Future,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+};
+
+use futures_channel::oneshot;
+use scoped_tls::scoped_thread_local;
+use web_sys::{
+    js_sys::Function,
+    wasm_bindgen::{closure::Closure, JsCast as _},
+    IdbRequest, IdbTransaction,
+};
+
+pub enum TransactionResult<R> {
+    PolledForbiddenThing,
+    Done(R),
+}
+
+pub struct RunnableTransaction<'f> {
+    transaction: IdbTransaction,
+    inflight_requests: Cell<usize>,
+    future: RefCell<Pin<Box<dyn 'f + Future<Output = ()>>>>,
+    polled_forbidden_thing: Box<dyn 'f + Fn()>,
+    finished: RefCell<Option<oneshot::Sender<()>>>,
+}
+
+impl<'f> RunnableTransaction<'f> {
+    pub fn new<R, E>(
+        transaction: IdbTransaction,
+        transaction_contents: impl 'f + Future<Output = Result<R, E>>,
+        result: &'f RefCell<Option<TransactionResult<Result<R, E>>>>,
+        finished: oneshot::Sender<()>,
+    ) -> RunnableTransaction<'f>
+    where
+        R: 'f,
+        E: 'f,
+    {
+        RunnableTransaction {
+            transaction: transaction.clone(),
+            inflight_requests: Cell::new(0),
+            future: RefCell::new(Box::pin(async move {
+                let transaction_result = transaction_contents.await;
+                if transaction_result.is_err() {
+                    // The transaction failed. We should abort it.
+                    let _ = transaction.abort();
+                }
+                assert!(
+                    result
+                        .replace(Some(TransactionResult::Done(transaction_result)))
+                        .is_none(),
+                    "Transaction completed multiple times",
+                );
+            })),
+            polled_forbidden_thing: Box::new(move || {
+                *result.borrow_mut() = Some(TransactionResult::PolledForbiddenThing);
+            }),
+            finished: RefCell::new(Some(finished)),
+        }
+    }
+}
+
+fn panic_waker() -> Waker {
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(
+            std::ptr::null(),
+            &RawWakerVTable::new(clone, wake, wake, drop),
+        )
+    }
+    fn wake(_: *const ()) {
+        panic!("IndexedDB transaction tried to await on something other than a request")
+    }
+    fn drop(_: *const ()) {}
+    unsafe {
+        Waker::new(
+            std::ptr::null(),
+            &RawWakerVTable::new(clone, wake, wake, drop),
+        )
+    }
+}
+
+scoped_thread_local!(static CURRENT: Rc<RunnableTransaction<'static>>);
+
+pub fn poll_it(state: &Rc<RunnableTransaction<'static>>) {
+    CURRENT.set(&state, || {
+        // Poll once, in order to run the transaction until its next await on a request
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            state
+                .future
+                .borrow_mut()
+                .as_mut()
+                .poll(&mut Context::from_waker(&panic_waker()))
+        }));
+
+        // Try catching the panic and aborting. This currently does not work in wasm due to panic=abort, but will
+        // hopefully work some day. The transaction _should_ auto-abort if the wasm module aborts, so hopefully we're
+        // fine around there.
+        let res = match res {
+            Ok(res) => res,
+            Err(err) => {
+                // The poll panicked, abort the transaction
+                let _ = state.transaction.abort();
+                std::panic::resume_unwind(err);
+            }
+        };
+
+        // Finally, check the poll result
+        match res {
+            Poll::Pending => {
+                // Still some work to do. Is there at least one request in flight?
+                if state.inflight_requests.get() == 0 {
+                    // Returned `Pending` despite no request being inflight. This means there was
+                    // an `await` on something other than transaction requests. Abort in order to
+                    // avoid the default auto-commit behavior.
+                    let _ = state.transaction.abort();
+                    let _ = (state.polled_forbidden_thing)();
+                }
+            }
+            Poll::Ready(()) => {
+                // Everything went well! Just signal that we're done
+                let finished = state
+                    .finished
+                    .borrow_mut()
+                    .take()
+                    .expect("Transaction finished multiple times");
+                if finished.send(()).is_err() {
+                    // Transaction aborted by not awaiting on it
+                    let _ = state.transaction.abort();
+                    return;
+                }
+            }
+        }
+    });
+}
+
+pub fn add_request(
+    req: IdbRequest,
+    result: &Rc<RefCell<Option<Result<web_sys::Event, web_sys::Event>>>>,
+) -> impl Sized {
+    CURRENT.with(move |state| {
+        state
+            .inflight_requests
+            .set(state.inflight_requests.get() + 1);
+
+        let on_success = Closure::once({
+            let state = state.clone();
+            let result = result.clone();
+            move |evt: web_sys::Event| {
+                state
+                    .inflight_requests
+                    .set(state.inflight_requests.get() - 1);
+                assert!(result.replace(Some(Ok(evt))).is_none());
+                poll_it(&state);
+            }
+        });
+
+        let on_error = Closure::once({
+            let state = state.clone();
+            let result = result.clone();
+            move |evt: web_sys::Event| {
+                evt.prevent_default(); // Do not abort the transaction, we're dealing with it ourselves
+                state
+                    .inflight_requests
+                    .set(state.inflight_requests.get() - 1);
+                assert!(result.replace(Some(Err(evt))).is_none());
+                poll_it(&state);
+            }
+        });
+
+        req.set_onsuccess(Some(&on_success.as_ref().dyn_ref::<Function>().unwrap()));
+        req.set_onerror(Some(&on_error.as_ref().dyn_ref::<Function>().unwrap()));
+
+        // Keep the callbacks alive until they're no longer needed
+        (on_success, on_error)
+    })
+}

--- a/src/transaction/unsafe_jar.rs
+++ b/src/transaction/unsafe_jar.rs
@@ -134,7 +134,7 @@ impl<Args> ScopeCallback<Args> {
     }
 }
 
-/// Panics and aborts the whole process if the transaction is not dropped before the end of `must_be_dropped_before`
+/// Panics and aborts the whole process if the transaction is not dropped before the end of `scope`
 pub async fn extend_lifetime_to_scope_and_run<'scope, MakerArgs, ScopeRet>(
     maker: Box<dyn 'scope + FnOnce(MakerArgs) -> RunnableTransaction<'scope>>,
     scope: impl 'scope + AsyncFnOnce(ScopeCallback<MakerArgs>) -> ScopeRet,

--- a/src/transaction/unsafe_jar.rs
+++ b/src/transaction/unsafe_jar.rs
@@ -11,11 +11,12 @@ use futures_channel::oneshot;
 use futures_util::{task::noop_waker, FutureExt};
 use scoped_tls::scoped_thread_local;
 use std::{
-    cell::{Cell, RefCell},
+    cell::{Cell, OnceCell, RefCell},
     future::Future,
+    marker::PhantomData,
     panic::AssertUnwindSafe,
     pin::Pin,
-    rc::Rc,
+    rc::{Rc, Weak},
     task::{Context, Poll},
 };
 use web_sys::{
@@ -112,42 +113,64 @@ fn poll_it(state: &Rc<RunnableTransaction<'static>>) {
     });
 }
 
-pub fn run(state: RunnableTransaction<'static>) {
-    let state = Rc::new(state);
-    poll_it(&state);
+pub struct ScopeCallback<'scope, Args> {
+    state: Rc<OnceCell<Weak<RunnableTransaction<'static>>>>,
+    maker: Option<Box<dyn 'static + FnOnce(Args) -> RunnableTransaction<'static>>>,
+
+    // 'static itself, but also invariant in 'scope
+    // See the definition of std::thread::Scope for why invariance is important.
+    _phantom: PhantomData<fn(&'scope ()) -> &'scope ()>,
+}
+
+impl<'scope, Args> ScopeCallback<'scope, Args> {
+    pub fn set_maker(&mut self, maker: impl 'scope + FnOnce(Args) -> RunnableTransaction<'scope>) {
+        // TODO: this is not safe, but can be made safe by adjusting the Rc checks
+        let maker: Box<dyn 'scope + FnOnce(Args) -> RunnableTransaction<'scope>> = Box::new(maker);
+        let maker: Box<dyn 'static + FnOnce(Args) -> RunnableTransaction<'static>> =
+            unsafe { std::mem::transmute(maker) };
+        self.maker = Some(maker);
+    }
+
+    pub fn run(mut self, args: Args) {
+        let maker = self.maker.take().expect("Bug in the indexed-db crate: called ScopeCallback::run without calling ScopeCallback::set_maker first");
+        let state: RunnableTransaction<'static> = (maker)(args);
+        // SAFETY: We're extending the lifetime of `state` to `'static`.
+        // This is safe because the `RunnableTransaction` is not stored anywhere else, and it will be dropped
+        // before the end of the enclosing `extend_lifetime_to_scope_and_run` call, at the `Weak::strong_count` check.
+        // If it is not, we'll panic and abort the whole process.
+        // `'scope` is also guaranteed to outlive `extend_lifetime_to_scope_and_run`.
+        let state: RunnableTransaction<'static> = unsafe { std::mem::transmute(state) };
+        let state = Rc::new(state);
+        let _ = self.state.set(Rc::downgrade(&state));
+        poll_it(&state);
+    }
 }
 
 /// Panics and aborts the whole process if the transaction is not dropped before the end of `must_be_dropped_before`
-pub async fn extend_lifetime_and_run<'f, R>(
-    state: RunnableTransaction<'f>,
-    must_be_dropped_before: impl AsyncFnOnce() -> R,
-) -> R {
-    // SAFETY: We're extending the lifetime of `state` to `'static`.
-    // This is safe because the `RunnableTransaction` is not stored anywhere else, and it will be dropped
-    // before the end of the `must_be_dropped_before` future.
-    // If it is not, we'll panic and abort the whole process.
-    // The `Rc::strong_count` check is there to ensure that the transaction is dropped before the end of its lifetime.
-    let state: RunnableTransaction<'static> = unsafe { std::mem::transmute(state) };
-    let state = Rc::new(state);
-    // Abort on panic if there's remaining references, there's nothing recoverable if we overextended the lifetime
-    let result = AssertUnwindSafe(async {
-        poll_it(&state);
-        let result = must_be_dropped_before().await;
-        // Note: we know this won't spuriously hit because:
-        // - we're having `Rc`, so every `RunnableTransaction` operation is single-thread anyway
-        // - when `must_be_dropped_before` completes, at least `result_rx` or `polled_forbidden_thing_rx` will have resolved
-        // - either of these channels being written to, means that the `RunnableTransaction` has been dropped
-        // Point 2 is enforced outside of the unsafe jar, but it's fine considering it will only result in a spurious panic/abort
-        if Rc::strong_count(&state) != 1 {
-            panic!("Bug in the indexed-db crate: the transaction was not dropped before the end of its lifetime");
+pub async fn extend_lifetime_to_scope_and_run<'scope, ScopeArgs, ScopeRet>(
+    scope: impl AsyncFnOnce(ScopeCallback<'scope, ScopeArgs>) -> ScopeRet,
+) -> ScopeRet {
+    let state = Rc::new(OnceCell::new());
+    let callback = ScopeCallback {
+        state: state.clone(),
+        maker: None,
+        _phantom: PhantomData,
+    };
+    let result = AssertUnwindSafe((scope)(callback)).catch_unwind().await;
+    if let Some(state) = state.get() {
+        if Weak::strong_count(&state) != 0 {
+            // Make sure that regardless of what the user could be doing, if we're overextending the lifetime we'll panic and abort
+            //
+            // Note: we know this won't spuriously hit because:
+            // - we're using `Rc`, so every `RunnableTransaction` operation is single-thread anyway
+            // - when the scope completes, at least `result_rx` or `polled_forbidden_thing_rx` will have resolved
+            // - either of these channels being written to, means that the `RunnableTransaction` has been dropped
+            // Point 2 is enforced outside of the unsafe jar, but it's fine considering it will only result in a spurious panic/abort
+            let _ = std::panic::catch_unwind(|| {
+                panic!("Bug in the indexed-db crate: the transaction was not dropped before the end of its lifetime")
+            });
+            std::process::abort();
         }
-        result
-    })
-    .catch_unwind()
-    .await;
-    if Rc::strong_count(&state) != 1 {
-        // Make sure we abort regardless of what the user could be doing, if we're overextending the lifetime we'll also panic
-        std::process::abort();
     }
     match result {
         Ok(result) => result,

--- a/src/transaction/unsafe_jar.rs
+++ b/src/transaction/unsafe_jar.rs
@@ -199,8 +199,8 @@ pub async fn extend_lifetime_to_scope_and_run<'scope, MakerArgs, ScopeRet>(
             //
             // Note: we know this won't spuriously hit because:
             // - we're using `Rc`, so every `RunnableTransaction` operation is single-thread anyway
-            // - when the scope completes, at least `result_rx` or `polled_forbidden_thing_rx` will have resolved
-            // - either of these channels being written to, means that the `RunnableTransaction` has been dropped
+            // - when the scope completes, `finished_rx` will have resolved
+            // - if `finished_tx` has been written to, it means that the `RunnableTransaction` has been dropped
             // Point 2 is enforced outside of the unsafe jar, but it's fine considering it will only result in a spurious panic/abort
             let _ = std::panic::catch_unwind(|| {
                 panic!("Bug in the indexed-db crate: the transaction was not dropped before the end of its lifetime")

--- a/src/transaction/unsafe_jar.rs
+++ b/src/transaction/unsafe_jar.rs
@@ -1,146 +1,16 @@
-//! All the required to run a transaction
-//!
 //! This module holds all the `unsafe` implementation details of `transaction`.
 //!
 //! The API exposed from here is entirely safe, and this module's code should be properly audited.
 
-use futures_channel::oneshot;
-use futures_util::FutureExt;
-use scoped_tls::scoped_thread_local;
 use std::{
-    cell::{Cell, OnceCell, RefCell},
-    future::Future,
+    cell::{Cell, OnceCell},
     panic::AssertUnwindSafe,
-    pin::Pin,
     rc::{Rc, Weak},
-    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
-};
-use web_sys::{
-    js_sys::Function,
-    wasm_bindgen::{closure::Closure, JsCast},
-    IdbRequest, IdbTransaction,
 };
 
-pub enum TransactionResult<R> {
-    PolledForbiddenThing,
-    Done(R),
-}
+use futures_util::FutureExt as _;
 
-pub struct RunnableTransaction<'f> {
-    transaction: IdbTransaction,
-    inflight_requests: Cell<usize>,
-    future: RefCell<Pin<Box<dyn 'f + Future<Output = ()>>>>,
-    polled_forbidden_thing: Box<dyn 'f + Fn()>,
-    finished: RefCell<Option<oneshot::Sender<()>>>,
-}
-
-impl<'f> RunnableTransaction<'f> {
-    pub fn new<R, E>(
-        transaction: IdbTransaction,
-        transaction_contents: impl 'f + Future<Output = Result<R, E>>,
-        result: &'f RefCell<Option<TransactionResult<Result<R, E>>>>,
-        finished: oneshot::Sender<()>,
-    ) -> RunnableTransaction<'f>
-    where
-        R: 'f,
-        E: 'f,
-    {
-        RunnableTransaction {
-            transaction: transaction.clone(),
-            inflight_requests: Cell::new(0),
-            future: RefCell::new(Box::pin(async move {
-                let transaction_result = transaction_contents.await;
-                if transaction_result.is_err() {
-                    // The transaction failed. We should abort it.
-                    let _ = transaction.abort();
-                }
-                assert!(
-                    result
-                        .replace(Some(TransactionResult::Done(transaction_result)))
-                        .is_none(),
-                    "Transaction completed multiple times",
-                );
-            })),
-            polled_forbidden_thing: Box::new(move || {
-                *result.borrow_mut() = Some(TransactionResult::PolledForbiddenThing);
-            }),
-            finished: RefCell::new(Some(finished)),
-        }
-    }
-}
-
-fn panic_waker() -> Waker {
-    fn clone(_: *const ()) -> RawWaker {
-        RawWaker::new(
-            std::ptr::null(),
-            &RawWakerVTable::new(clone, wake, wake, drop),
-        )
-    }
-    fn wake(_: *const ()) {
-        panic!("IndexedDB transaction tried to await on something other than a request")
-    }
-    fn drop(_: *const ()) {}
-    unsafe {
-        Waker::new(
-            std::ptr::null(),
-            &RawWakerVTable::new(clone, wake, wake, drop),
-        )
-    }
-}
-
-scoped_thread_local!(static CURRENT: Rc<RunnableTransaction<'static>>);
-
-fn poll_it(state: &Rc<RunnableTransaction<'static>>) {
-    CURRENT.set(&state, || {
-        // Poll once, in order to run the transaction until its next await on a request
-        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            state
-                .future
-                .borrow_mut()
-                .as_mut()
-                .poll(&mut Context::from_waker(&panic_waker()))
-        }));
-
-        // Try catching the panic and aborting. This currently does not work in wasm due to panic=abort, but will
-        // hopefully work some day. The transaction _should_ auto-abort if the wasm module aborts, so hopefully we're
-        // fine around there.
-        let res = match res {
-            Ok(res) => res,
-            Err(err) => {
-                // The poll panicked, abort the transaction
-                let _ = state.transaction.abort();
-                std::panic::resume_unwind(err);
-            }
-        };
-
-        // Finally, check the poll result
-        match res {
-            Poll::Pending => {
-                // Still some work to do. Is there at least one request in flight?
-                if state.inflight_requests.get() == 0 {
-                    // Returned `Pending` despite no request being inflight. This means there was
-                    // an `await` on something other than transaction requests. Abort in order to
-                    // avoid the default auto-commit behavior.
-                    let _ = state.transaction.abort();
-                    let _ = (state.polled_forbidden_thing)();
-                }
-            }
-            Poll::Ready(()) => {
-                // Everything went well! Just signal that we're done
-                let finished = state
-                    .finished
-                    .borrow_mut()
-                    .take()
-                    .expect("Transaction finished multiple times");
-                if finished.send(()).is_err() {
-                    // Transaction aborted by not awaiting on it
-                    let _ = state.transaction.abort();
-                    return;
-                }
-            }
-        }
-    });
-}
+use super::{runner::poll_it, RunnableTransaction};
 
 struct DropFlag(Rc<Cell<bool>>);
 
@@ -212,46 +82,4 @@ pub async fn extend_lifetime_to_scope_and_run<'scope, MakerArgs, ScopeRet>(
         Ok(result) => result,
         Err(err) => std::panic::resume_unwind(err),
     }
-}
-
-pub fn add_request(
-    req: IdbRequest,
-    result: &Rc<RefCell<Option<Result<web_sys::Event, web_sys::Event>>>>,
-) -> impl Sized {
-    CURRENT.with(move |state| {
-        state
-            .inflight_requests
-            .set(state.inflight_requests.get() + 1);
-
-        let on_success = Closure::once({
-            let state = state.clone();
-            let result = result.clone();
-            move |evt: web_sys::Event| {
-                state
-                    .inflight_requests
-                    .set(state.inflight_requests.get() - 1);
-                assert!(result.replace(Some(Ok(evt))).is_none());
-                poll_it(&state);
-            }
-        });
-
-        let on_error = Closure::once({
-            let state = state.clone();
-            let result = result.clone();
-            move |evt: web_sys::Event| {
-                evt.prevent_default(); // Do not abort the transaction, we're dealing with it ourselves
-                state
-                    .inflight_requests
-                    .set(state.inflight_requests.get() - 1);
-                assert!(result.replace(Some(Err(evt))).is_none());
-                poll_it(&state);
-            }
-        });
-
-        req.set_onsuccess(Some(&on_success.as_ref().dyn_ref::<Function>().unwrap()));
-        req.set_onerror(Some(&on_error.as_ref().dyn_ref::<Function>().unwrap()));
-
-        // Keep the callbacks alive until they're no longer needed
-        (on_success, on_error)
-    })
 }

--- a/src/transaction/unsafe_jar.rs
+++ b/src/transaction/unsafe_jar.rs
@@ -1,9 +1,6 @@
 //! All the required to run a transaction
 //!
-//! Originally, this module was used for extracting the `unsafe` implementation details of `transaction`.
-//! Since then, all the code here has been made safe.
-//! However, it is possible that in the future, we'll need more unsafe code, in which case it would likely
-//! have to come here.
+//! This module holds all the `unsafe` implementation details of `transaction`.
 //!
 //! The API exposed from here is entirely safe, and this module's code should be properly audited.
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,9 @@ use web_sys::{
     DomException, IdbKeyRange, IdbRequest,
 };
 
-pub(crate) async fn generic_request(req: IdbRequest) -> Result<web_sys::Event, web_sys::Event> {
+pub(crate) async fn non_transaction_request(
+    req: IdbRequest,
+) -> Result<web_sys::Event, web_sys::Event> {
     let (success_tx, success_rx) = oneshot::channel();
     let (error_tx, error_rx) = oneshot::channel();
 


### PR DESCRIPTION
@touilleMan you completely nerd-sniped me into figuring out a way to safely relax the lifetime requirement :laughing: 

I'm around 95% confident that `extend_lifetime_and_run` is actually safe; I'll also ask around just to be sure before I land it :)

Unfortunately, this scheme does not expand to the version-upgrade transaction, because there's no obvious way to explicitly claim "the transaction must be done by this point in time". OTOH, I'd also expect version-upgrade transactions to benefit from it less anyway, so it might not be worth the effort to relax the lifetimes.

WDYT?

On my end, the thing I'd fear most would be, that there'd be some delay between when `must_be_dropped_before` resolves (because the channel was pushed to) and when the `Rc` is actually dropped, leading to an abort… but I'm not entirely sure how to deal with that cleanly just yet :/