### PR TITLE
Database close on drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ futures = "0.3.30"
 tracing = "0.1.40"
 tracing-wasm = "0.2.1"
 wasm-bindgen-test = "=0.3.50"
+web-sys = { version = "0.3.66", features = [ "Performance" ] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -3,26 +3,30 @@ use web_sys::IdbDatabase;
 
 /// Wrapper for [`IDBDatabase`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase)
 ///
-/// Note dropping this wrapper automatically calls [`IDBDatabase::close`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close)
+/// Note that dropping this wrapper automatically calls [`IDBDatabase::close`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close)
 /// to request the underlying database connection to be closed (the actual database close
 /// occuring asynchronously with no way for the client to identify when this happens).
 #[derive(Debug)]
 pub struct OwnedDatabase(
     /// This field only switches to `None` to prevent database close on drop when
     /// `OwnedDatabase::into_manual_close` is used.
-    Option<Database>,
+    pub(crate) Option<Database>,
 );
 
 impl OwnedDatabase {
     /// Convert this into a [`Database`] that does not automatically close the connection when dropped.
+    ///
+    /// The resulting [`Database`] is `Clone` without requiring reference-counting, which can be more convenient than refcounting [`OwnedDatabase`]
     pub fn into_manual_close(mut self) -> Database {
         self.0.take().expect("Database already taken")
     }
-}
 
-impl From<Database> for OwnedDatabase {
-    fn from(db: Database) -> OwnedDatabase {
-        OwnedDatabase(Some(db))
+    /// Explicitly closes this database connection
+    ///
+    /// Calling this method is strictly equivalent to dropping the [`OwnedDatabase`] instance.
+    /// This method is only provided for symmetry with [`Database::close`].
+    pub fn close(self) {
+        // `self` is dropped here
     }
 }
 
@@ -38,7 +42,7 @@ impl Drop for OwnedDatabase {
     fn drop(&mut self) {
         match self.0.take() {
             Some(db) => db.close(),
-            None => {}
+            None => {} // Database was taken with `into_manual_close`
         }
     }
 }
@@ -47,8 +51,8 @@ impl Drop for OwnedDatabase {
 ///
 /// Unlike[``OwnedDatabase`], this does not automatically close the database connection when dropped.
 ///
-/// Note failing to close the database connection prior to dropping this wrapper will let the connection
-/// remain open until the Javascript garbage collector kicks in, which typically can take 10s of seconds
+/// Note that failing to close the database connection prior to dropping this wrapper will let the connection
+/// remain open until the Javascript garbage collector kicks in, which typically can take tens of seconds
 /// during which any new attempt to e.g. delete or open with upgrade the database will hang.
 #[derive(Debug)]
 pub struct Database {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1,6 +1,6 @@
 use crate::{
-    transaction::runner, utils::generic_request, utils::str_slice_to_array, Database, ObjectStore,
-    Transaction,
+    database::OwnedDatabase, transaction::runner, utils::generic_request,
+    utils::str_slice_to_array, Database, ObjectStore, Transaction,
 };
 use futures_channel::oneshot;
 use futures_util::{pin_mut, FutureExt};
@@ -99,7 +99,7 @@ impl Factory {
         name: &str,
         version: u32,
         on_upgrade_needed: impl 'static + AsyncFnOnce(VersionChangeEvent<Err>) -> crate::Result<(), Err>,
-    ) -> crate::Result<Database, Err>
+    ) -> crate::Result<OwnedDatabase, Err>
     where
         Err: 'static,
     {
@@ -154,7 +154,7 @@ impl Factory {
             .dyn_into::<IdbDatabase>()
             .expect("Result of successful IDBOpenDBRequest is not an IDBDatabase");
 
-        Ok(Database::from_sys(db))
+        Ok(Database::from_sys(db).into())
     }
 
     /// Open a database at the latest version

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -154,7 +154,7 @@ impl Factory {
             .dyn_into::<IdbDatabase>()
             .expect("Result of successful IDBOpenDBRequest is not an IDBDatabase");
 
-        Ok(Database::from_sys(db).into())
+        Ok(OwnedDatabase(Some(Database::from_sys(db))))
     }
 
     /// Open a database at the latest version


### PR DESCRIPTION
close #13 

The first commit showcase a issue, the second one introduce a `OwnedDatabase` type to fix it.

In practice `Database` cannot be modified to close on drop since it is also used by `VersionChangeEvent`.
So instead `OwnedDatabase` is a thin wrapper that simply calls `Database::close` on drop.