### PR TITLE
Attemps at removing the generic `Err`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,10 +16,10 @@ async fn example() -> anyhow::Result<()> {
             // You can also add objects from this callback
             store.add(&JsString::from("foo")).await?;
 
-            Ok(Ok(()))
+            Ok(())
         })
         .await
-        .context("creating the 'database' IndexedDB")??;
+        .context("creating the 'database' IndexedDB")?;
 
     // In a transaction, add two records
     db.transaction(&["store"])
@@ -28,23 +28,23 @@ async fn example() -> anyhow::Result<()> {
             let store = t.object_store("store")?;
             store.add(&JsString::from("bar")).await?;
             store.add(&JsString::from("baz")).await?;
-            Ok(Ok(()))
+            Ok(())
         })
-        .await??;
+        .await?;
 
     // In another transaction, read the first record
     db.transaction(&["store"])
         .run::<_, std::io::Error>(async move |t| {
             let data = t.object_store("store")?.get_all(Some(1)).await?;
             if data.len() != 1 {
-                return Ok(Err(std::io::Error::new(
+                return Err(indexed_db::CallbackError::User(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Unexpected data length",
                 )));
             }
-            Ok(Ok(()))
+            Ok(())
         })
-        .await??;
+        .await?;
 
     // If we return `Err` (or panic) from a transaction, then it will abort
     db.transaction(&["store"])
@@ -54,12 +54,12 @@ async fn example() -> anyhow::Result<()> {
             store.add(&JsString::from("quux")).await?;
             if store.count().await? > 3 {
                 // Oops! In this example, we have 4 items by this point
-                return Ok(Err(std::io::Error::new(
+                return Err(indexed_db::CallbackError::User(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Too many objects in store",
                 )));
             }
-            Ok(Ok(()))
+            Ok(())
         })
         .await
         .unwrap_err();
@@ -69,9 +69,9 @@ async fn example() -> anyhow::Result<()> {
         .run::<_, Infallible>(async move |t| {
             let num_items = t.object_store("store")?.count().await?;
             assert_eq!(num_items, 3);
-            Ok(Ok(()))
+            Ok(())
         })
-        .await??;
+        .await?;
 
     // More complex example: using cursors to iterate over a store
     db.transaction(&["store"])
@@ -84,9 +84,9 @@ async fn example() -> anyhow::Result<()> {
             }
             assert_eq!(all_items.len(), 3);
             assert_eq!(all_items[0], **JsString::from("foo"));
-            Ok(Ok(()))
+            Ok(())
         })
-        .await??;
+        .await?;
 
     Ok(())
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use futures_util::future::Either;
-use std::{convert::Infallible, future::Future, ops::RangeBounds};
+use std::{future::Future, ops::RangeBounds};
 use web_sys::{
     wasm_bindgen::{JsCast, JsValue},
     IdbCursor, IdbCursorDirection, IdbCursorWithValue, IdbIndex, IdbObjectStore, IdbRequest,
@@ -71,7 +71,7 @@ impl CursorBuilder {
     /// Open the cursor
     ///
     /// Internally, this uses [`IDBObjectStore::openCursor`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/openCursor).
-    pub fn open(self) -> impl Future<Output = crate::Result<Cursor, Infallible>> {
+    pub fn open(self) -> impl Future<Output = crate::Result<Cursor>> {
         let req = match self.source {
             Either::Left(store) => {
                 store.open_cursor_with_range_and_direction(&self.query, self.direction)
@@ -89,7 +89,7 @@ impl CursorBuilder {
     /// Open the cursor as a key-only cursor
     ///
     /// Internally, this uses [`IDBObjectStore::openKeyCursor`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/openKeyCursor).
-    pub fn open_key(self) -> impl Future<Output = crate::Result<Cursor, Infallible>> {
+    pub fn open_key(self) -> impl Future<Output = crate::Result<Cursor>> {
         let req = match self.source {
             Either::Left(store) => {
                 store.open_key_cursor_with_range_and_direction(&self.query, self.direction)
@@ -107,7 +107,7 @@ impl CursorBuilder {
     /// Limit the range of the cursor
     ///
     /// Internally, this sets [this property](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/openCursor#range).
-    pub fn range(mut self, range: impl RangeBounds<JsValue>) -> crate::Result<Self, Infallible> {
+    pub fn range(mut self, range: impl RangeBounds<JsValue>) -> crate::Result<Self> {
         self.query = make_key_range(range)?;
         Ok(self)
     }
@@ -128,7 +128,7 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub(crate) async fn from(req: IdbRequest) -> crate::Result<Cursor, Infallible> {
+    pub(crate) async fn from(req: IdbRequest) -> crate::Result<Cursor> {
         let res = transaction_request(req.clone())
             .await
             .map_err(map_open_cursor_err)?;
@@ -180,7 +180,7 @@ impl Cursor {
     /// Advance this [`Cursor`] by `count` elements
     ///
     /// Internally, this uses [`IDBCursor::advance`](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/advance).
-    pub async fn advance(&mut self, count: u32) -> crate::Result<(), Infallible> {
+    pub async fn advance(&mut self, count: u32) -> crate::Result<()> {
         let Some(sys) = &self.sys else {
             return Err(crate::Error::CursorCompleted);
         };
@@ -198,7 +198,7 @@ impl Cursor {
     /// Advance this [`Cursor`] until the provided key
     ///
     /// Internally, this uses [`IDBCursor::continue`](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/continue).
-    pub async fn advance_until(&mut self, key: &JsValue) -> crate::Result<(), Infallible> {
+    pub async fn advance_until(&mut self, key: &JsValue) -> crate::Result<()> {
         let Some(sys) = &self.sys else {
             return Err(crate::Error::CursorCompleted);
         };
@@ -228,7 +228,7 @@ impl Cursor {
         &mut self,
         index_key: &JsValue,
         primary_key: &JsValue,
-    ) -> crate::Result<(), Infallible> {
+    ) -> crate::Result<()> {
         let Some(sys) = &self.sys else {
             return Err(crate::Error::CursorCompleted);
         };
@@ -249,7 +249,7 @@ impl Cursor {
     /// Note that this method does not work on key-only cursors over indexes.
     ///
     /// Internally, this uses [`IDBCursor::delete`](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/delete).
-    pub async fn delete(&self) -> crate::Result<(), Infallible> {
+    pub async fn delete(&self) -> crate::Result<()> {
         let Some(sys) = &self.sys else {
             return Err(crate::Error::CursorCompleted);
         };
@@ -265,7 +265,7 @@ impl Cursor {
     /// Note that this method does not work on key-only cursors over indexes.
     ///
     /// Internally, this uses [`IDBCursor::update`](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/update).
-    pub async fn update(&self, value: &JsValue) -> crate::Result<(), Infallible> {
+    pub async fn update(&self, value: &JsValue) -> crate::Result<()> {
         let Some(sys) = &self.sys else {
             return Err(crate::Error::CursorCompleted);
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,3 +112,157 @@ impl<Err> Error<Err> {
 pub(crate) fn name(v: &JsValue) -> Option<String> {
     v.dyn_ref::<web_sys::DomException>().map(|v| v.name())
 }
+
+// Approach 1: Allow automatic conversion of `Error<Infallible>` into `Error<Err>`
+//
+// However the conversion clashes with `impl<T> From<T> for T` (probably a limitation
+// in Rust that doesn't support specialization).
+
+impl<Err> From<Error<std::convert::Infallible>> for Error<Err> {
+    fn from(value: Error<std::convert::Infallible>) -> Self {
+        match value {
+            Error::NotInBrowser => Error::NotInBrowser,
+            Error::IndexedDbDisabled => Error::IndexedDbDisabled,
+            Error::OperationNotSupported => Error::OperationNotSupported,
+            Error::OperationNotAllowed => Error::OperationNotAllowed,
+            Error::InvalidKey => Error::InvalidKey,
+            Error::VersionMustNotBeZero => Error::VersionMustNotBeZero,
+            Error::VersionTooOld => Error::VersionTooOld,
+            Error::InvalidCall => Error::InvalidCall,
+            Error::InvalidArgument => Error::InvalidArgument,
+            Error::AlreadyExists => Error::AlreadyExists,
+            Error::DoesNotExist => Error::DoesNotExist,
+            Error::DatabaseIsClosed => Error::DatabaseIsClosed,
+            Error::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
+            Error::ReadOnly => Error::ReadOnly,
+            Error::FailedClone => Error::FailedClone,
+            Error::InvalidRange => Error::InvalidRange,
+            Error::CursorCompleted => Error::CursorCompleted,
+            Error::User(_) => unreachable!(),
+        }
+    }
+}
+
+// Approach 2: Introduce a new `IndexdedDbOnlyError` error type when the error never
+// contains a user-defined error type.
+//
+// However the conversion `impl<Err> From<IndexdedDbOnlyError> for Error<Err>` clashes
+// with `Error::User(#[from] E)` :'(
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum IndexdedDbOnlyError {
+    /// Not running in a browser window
+    #[error("Not running in a browser window")]
+    NotInBrowser,
+
+    /// IndexedDB is disabled
+    #[error("IndexedDB is disabled")]
+    IndexedDbDisabled,
+
+    /// Operation is not supported by the browser
+    #[error("Operation is not supported by the browser")]
+    OperationNotSupported,
+
+    /// Operation is not allowed by the user agent
+    #[error("Operation is not allowed by the user agent")]
+    OperationNotAllowed,
+
+    /// Provided key is not valid
+    #[error("Provided key is not valid")]
+    InvalidKey,
+
+    /// Version must not be zero
+    #[error("Version must not be zero")]
+    VersionMustNotBeZero,
+
+    /// Requested version is older than existing version
+    #[error("Requested version is older than existing version")]
+    VersionTooOld,
+
+    /// The requested function cannot be called from this context
+    #[error("The requested function cannot be called from this context")]
+    InvalidCall,
+
+    /// The provided arguments are invalid
+    #[error("The provided arguments are invalid")]
+    InvalidArgument,
+
+    /// Cannot create something that already exists
+    #[error("Cannot create something that already exists")]
+    AlreadyExists,
+
+    /// Cannot change something that does not exists
+    #[error("Cannot change something that does not exists")]
+    DoesNotExist,
+
+    /// Database is closed
+    #[error("Database is closed")]
+    DatabaseIsClosed,
+
+    /// Object store was removed
+    #[error("Object store was removed")]
+    ObjectStoreWasRemoved,
+
+    /// Transaction is read-only
+    #[error("Transaction is read-only")]
+    ReadOnly,
+
+    /// Unable to clone
+    #[error("Unable to clone")]
+    FailedClone,
+
+    /// Invalid range
+    #[error("Invalid range")]
+    InvalidRange,
+
+    /// Cursor finished its range
+    #[error("Cursor finished its range")]
+    CursorCompleted,
+}
+
+impl IndexdedDbOnlyError {
+    pub(crate) fn from_dom_exception(err: DomException) -> IndexdedDbOnlyError {
+        match &err.name() as &str {
+            "NotSupportedError" => Self::OperationNotSupported,
+            "NotAllowedError" => Self::OperationNotAllowed,
+            "VersionError" => Self::VersionTooOld,
+            _ => panic!("Unexpected error: {err:?}"),
+        }
+    }
+
+    pub(crate) fn from_js_value(v: JsValue) -> IndexdedDbOnlyError {
+        let err = v
+            .dyn_into::<web_sys::DomException>()
+            .expect("Trying to parse indexed_db::Error from value that is not a DomException");
+        IndexdedDbOnlyError::from_dom_exception(err)
+    }
+
+    pub(crate) fn from_js_event(evt: web_sys::Event) -> IndexdedDbOnlyError {
+        IndexdedDbOnlyError::from_dom_exception(err_from_event(evt))
+    }
+}
+
+impl<Err> From<IndexdedDbOnlyError> for Error<Err> {
+    fn from(value: IndexdedDbOnlyError) -> Self {
+        match value {
+            IndexdedDbOnlyError::NotInBrowser => Error::NotInBrowser,
+            IndexdedDbOnlyError::IndexedDbDisabled => Error::IndexedDbDisabled,
+            IndexdedDbOnlyError::OperationNotSupported => Error::OperationNotSupported,
+            IndexdedDbOnlyError::OperationNotAllowed => Error::OperationNotAllowed,
+            IndexdedDbOnlyError::InvalidKey => Error::InvalidKey,
+            IndexdedDbOnlyError::VersionMustNotBeZero => Error::VersionMustNotBeZero,
+            IndexdedDbOnlyError::VersionTooOld => Error::VersionTooOld,
+            IndexdedDbOnlyError::InvalidCall => Error::InvalidCall,
+            IndexdedDbOnlyError::InvalidArgument => Error::InvalidArgument,
+            IndexdedDbOnlyError::AlreadyExists => Error::AlreadyExists,
+            IndexdedDbOnlyError::DoesNotExist => Error::DoesNotExist,
+            IndexdedDbOnlyError::DatabaseIsClosed => Error::DatabaseIsClosed,
+            IndexdedDbOnlyError::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
+            IndexdedDbOnlyError::ReadOnly => Error::ReadOnly,
+            IndexdedDbOnlyError::FailedClone => Error::FailedClone,
+            IndexdedDbOnlyError::InvalidRange => Error::InvalidRange,
+            IndexdedDbOnlyError::CursorCompleted => Error::CursorCompleted,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,10 +7,16 @@ use web_sys::{
 /// Type alias for convenience
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Error type for all errors from this crate, plus a user-defined error.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum CallbackError<E> {
+    #[error(transparent)]
+    IndexedDb(#[from] Error),
+    #[error("User error: {0}")]
+    User(E),
+}
+
 /// Error type for all errors from this crate
-///
-/// The `E` generic argument is used for user-defined error types, eg. when
-/// the user provides a callback.
 #[derive(Clone, Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use web_sys::{
 };
 
 /// Type alias for convenience
-pub type Result<T, E> = std::result::Result<T, Error<E>>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error type for all errors from this crate
 ///
@@ -13,7 +13,7 @@ pub type Result<T, E> = std::result::Result<T, Error<E>>;
 /// the user provides a callback.
 #[derive(Clone, Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum Error<E> {
+pub enum Error {
     /// Not running in a browser window
     #[error("Not running in a browser window")]
     NotInBrowser,
@@ -81,14 +81,10 @@ pub enum Error<E> {
     /// Cursor finished its range
     #[error("Cursor finished its range")]
     CursorCompleted,
-
-    /// User-provided error to pass through `indexed-db` code
-    #[error(transparent)]
-    User(#[from] E),
 }
 
-impl<Err> Error<Err> {
-    pub(crate) fn from_dom_exception(err: DomException) -> Error<Err> {
+impl Error {
+    pub(crate) fn from_dom_exception(err: DomException) -> Error {
         match &err.name() as &str {
             "NotSupportedError" => crate::Error::OperationNotSupported,
             "NotAllowedError" => crate::Error::OperationNotAllowed,
@@ -97,14 +93,14 @@ impl<Err> Error<Err> {
         }
     }
 
-    pub(crate) fn from_js_value(v: JsValue) -> Error<Err> {
+    pub(crate) fn from_js_value(v: JsValue) -> Error {
         let err = v
             .dyn_into::<web_sys::DomException>()
             .expect("Trying to parse indexed_db::Error from value that is not a DomException");
         Error::from_dom_exception(err)
     }
 
-    pub(crate) fn from_js_event(evt: web_sys::Event) -> Error<Err> {
+    pub(crate) fn from_js_event(evt: web_sys::Event) -> Error {
         Error::from_dom_exception(err_from_event(evt))
     }
 }
@@ -113,156 +109,156 @@ pub(crate) fn name(v: &JsValue) -> Option<String> {
     v.dyn_ref::<web_sys::DomException>().map(|v| v.name())
 }
 
-// Approach 1: Allow automatic conversion of `Error<Infallible>` into `Error<Err>`
-//
-// However the conversion clashes with `impl<T> From<T> for T` (probably a limitation
-// in Rust that doesn't support specialization).
+// // Approach 1: Allow automatic conversion of `Error<Infallible>` into `Error<Err>`
+// //
+// // However the conversion clashes with `impl<T> From<T> for T` (probably a limitation
+// // in Rust that doesn't support specialization).
 
-impl<Err> From<Error<std::convert::Infallible>> for Error<Err> {
-    fn from(value: Error<std::convert::Infallible>) -> Self {
-        match value {
-            Error::NotInBrowser => Error::NotInBrowser,
-            Error::IndexedDbDisabled => Error::IndexedDbDisabled,
-            Error::OperationNotSupported => Error::OperationNotSupported,
-            Error::OperationNotAllowed => Error::OperationNotAllowed,
-            Error::InvalidKey => Error::InvalidKey,
-            Error::VersionMustNotBeZero => Error::VersionMustNotBeZero,
-            Error::VersionTooOld => Error::VersionTooOld,
-            Error::InvalidCall => Error::InvalidCall,
-            Error::InvalidArgument => Error::InvalidArgument,
-            Error::AlreadyExists => Error::AlreadyExists,
-            Error::DoesNotExist => Error::DoesNotExist,
-            Error::DatabaseIsClosed => Error::DatabaseIsClosed,
-            Error::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
-            Error::ReadOnly => Error::ReadOnly,
-            Error::FailedClone => Error::FailedClone,
-            Error::InvalidRange => Error::InvalidRange,
-            Error::CursorCompleted => Error::CursorCompleted,
-            Error::User(_) => unreachable!(),
-        }
-    }
-}
+// impl<Err> From<Error<std::convert::Infallible>> for Error<Err> {
+//     fn from(value: Error<std::convert::Infallible>) -> Self {
+//         match value {
+//             Error::NotInBrowser => Error::NotInBrowser,
+//             Error::IndexedDbDisabled => Error::IndexedDbDisabled,
+//             Error::OperationNotSupported => Error::OperationNotSupported,
+//             Error::OperationNotAllowed => Error::OperationNotAllowed,
+//             Error::InvalidKey => Error::InvalidKey,
+//             Error::VersionMustNotBeZero => Error::VersionMustNotBeZero,
+//             Error::VersionTooOld => Error::VersionTooOld,
+//             Error::InvalidCall => Error::InvalidCall,
+//             Error::InvalidArgument => Error::InvalidArgument,
+//             Error::AlreadyExists => Error::AlreadyExists,
+//             Error::DoesNotExist => Error::DoesNotExist,
+//             Error::DatabaseIsClosed => Error::DatabaseIsClosed,
+//             Error::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
+//             Error::ReadOnly => Error::ReadOnly,
+//             Error::FailedClone => Error::FailedClone,
+//             Error::InvalidRange => Error::InvalidRange,
+//             Error::CursorCompleted => Error::CursorCompleted,
+//             Error::User(_) => unreachable!(),
+//         }
+//     }
+// }
 
-// Approach 2: Introduce a new `IndexdedDbOnlyError` error type when the error never
-// contains a user-defined error type.
-//
-// However the conversion `impl<Err> From<IndexdedDbOnlyError> for Error<Err>` clashes
-// with `Error::User(#[from] E)` :'(
+// // Approach 2: Introduce a new `IndexdedDbOnlyError` error type when the error never
+// // contains a user-defined error type.
+// //
+// // However the conversion `impl<Err> From<IndexdedDbOnlyError> for Error<Err>` clashes
+// // with `Error::User(#[from] E)` :'(
 
-#[derive(Clone, Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum IndexdedDbOnlyError {
-    /// Not running in a browser window
-    #[error("Not running in a browser window")]
-    NotInBrowser,
+// #[derive(Clone, Debug, thiserror::Error)]
+// #[non_exhaustive]
+// pub enum IndexdedDbOnlyError {
+//     /// Not running in a browser window
+//     #[error("Not running in a browser window")]
+//     NotInBrowser,
 
-    /// IndexedDB is disabled
-    #[error("IndexedDB is disabled")]
-    IndexedDbDisabled,
+//     /// IndexedDB is disabled
+//     #[error("IndexedDB is disabled")]
+//     IndexedDbDisabled,
 
-    /// Operation is not supported by the browser
-    #[error("Operation is not supported by the browser")]
-    OperationNotSupported,
+//     /// Operation is not supported by the browser
+//     #[error("Operation is not supported by the browser")]
+//     OperationNotSupported,
 
-    /// Operation is not allowed by the user agent
-    #[error("Operation is not allowed by the user agent")]
-    OperationNotAllowed,
+//     /// Operation is not allowed by the user agent
+//     #[error("Operation is not allowed by the user agent")]
+//     OperationNotAllowed,
 
-    /// Provided key is not valid
-    #[error("Provided key is not valid")]
-    InvalidKey,
+//     /// Provided key is not valid
+//     #[error("Provided key is not valid")]
+//     InvalidKey,
 
-    /// Version must not be zero
-    #[error("Version must not be zero")]
-    VersionMustNotBeZero,
+//     /// Version must not be zero
+//     #[error("Version must not be zero")]
+//     VersionMustNotBeZero,
 
-    /// Requested version is older than existing version
-    #[error("Requested version is older than existing version")]
-    VersionTooOld,
+//     /// Requested version is older than existing version
+//     #[error("Requested version is older than existing version")]
+//     VersionTooOld,
 
-    /// The requested function cannot be called from this context
-    #[error("The requested function cannot be called from this context")]
-    InvalidCall,
+//     /// The requested function cannot be called from this context
+//     #[error("The requested function cannot be called from this context")]
+//     InvalidCall,
 
-    /// The provided arguments are invalid
-    #[error("The provided arguments are invalid")]
-    InvalidArgument,
+//     /// The provided arguments are invalid
+//     #[error("The provided arguments are invalid")]
+//     InvalidArgument,
 
-    /// Cannot create something that already exists
-    #[error("Cannot create something that already exists")]
-    AlreadyExists,
+//     /// Cannot create something that already exists
+//     #[error("Cannot create something that already exists")]
+//     AlreadyExists,
 
-    /// Cannot change something that does not exists
-    #[error("Cannot change something that does not exists")]
-    DoesNotExist,
+//     /// Cannot change something that does not exists
+//     #[error("Cannot change something that does not exists")]
+//     DoesNotExist,
 
-    /// Database is closed
-    #[error("Database is closed")]
-    DatabaseIsClosed,
+//     /// Database is closed
+//     #[error("Database is closed")]
+//     DatabaseIsClosed,
 
-    /// Object store was removed
-    #[error("Object store was removed")]
-    ObjectStoreWasRemoved,
+//     /// Object store was removed
+//     #[error("Object store was removed")]
+//     ObjectStoreWasRemoved,
 
-    /// Transaction is read-only
-    #[error("Transaction is read-only")]
-    ReadOnly,
+//     /// Transaction is read-only
+//     #[error("Transaction is read-only")]
+//     ReadOnly,
 
-    /// Unable to clone
-    #[error("Unable to clone")]
-    FailedClone,
+//     /// Unable to clone
+//     #[error("Unable to clone")]
+//     FailedClone,
 
-    /// Invalid range
-    #[error("Invalid range")]
-    InvalidRange,
+//     /// Invalid range
+//     #[error("Invalid range")]
+//     InvalidRange,
 
-    /// Cursor finished its range
-    #[error("Cursor finished its range")]
-    CursorCompleted,
-}
+//     /// Cursor finished its range
+//     #[error("Cursor finished its range")]
+//     CursorCompleted,
+// }
 
-impl IndexdedDbOnlyError {
-    pub(crate) fn from_dom_exception(err: DomException) -> IndexdedDbOnlyError {
-        match &err.name() as &str {
-            "NotSupportedError" => Self::OperationNotSupported,
-            "NotAllowedError" => Self::OperationNotAllowed,
-            "VersionError" => Self::VersionTooOld,
-            _ => panic!("Unexpected error: {err:?}"),
-        }
-    }
+// impl IndexdedDbOnlyError {
+//     pub(crate) fn from_dom_exception(err: DomException) -> IndexdedDbOnlyError {
+//         match &err.name() as &str {
+//             "NotSupportedError" => Self::OperationNotSupported,
+//             "NotAllowedError" => Self::OperationNotAllowed,
+//             "VersionError" => Self::VersionTooOld,
+//             _ => panic!("Unexpected error: {err:?}"),
+//         }
+//     }
 
-    pub(crate) fn from_js_value(v: JsValue) -> IndexdedDbOnlyError {
-        let err = v
-            .dyn_into::<web_sys::DomException>()
-            .expect("Trying to parse indexed_db::Error from value that is not a DomException");
-        IndexdedDbOnlyError::from_dom_exception(err)
-    }
+//     pub(crate) fn from_js_value(v: JsValue) -> IndexdedDbOnlyError {
+//         let err = v
+//             .dyn_into::<web_sys::DomException>()
+//             .expect("Trying to parse indexed_db::Error from value that is not a DomException");
+//         IndexdedDbOnlyError::from_dom_exception(err)
+//     }
 
-    pub(crate) fn from_js_event(evt: web_sys::Event) -> IndexdedDbOnlyError {
-        IndexdedDbOnlyError::from_dom_exception(err_from_event(evt))
-    }
-}
+//     pub(crate) fn from_js_event(evt: web_sys::Event) -> IndexdedDbOnlyError {
+//         IndexdedDbOnlyError::from_dom_exception(err_from_event(evt))
+//     }
+// }
 
-impl<Err> From<IndexdedDbOnlyError> for Error<Err> {
-    fn from(value: IndexdedDbOnlyError) -> Self {
-        match value {
-            IndexdedDbOnlyError::NotInBrowser => Error::NotInBrowser,
-            IndexdedDbOnlyError::IndexedDbDisabled => Error::IndexedDbDisabled,
-            IndexdedDbOnlyError::OperationNotSupported => Error::OperationNotSupported,
-            IndexdedDbOnlyError::OperationNotAllowed => Error::OperationNotAllowed,
-            IndexdedDbOnlyError::InvalidKey => Error::InvalidKey,
-            IndexdedDbOnlyError::VersionMustNotBeZero => Error::VersionMustNotBeZero,
-            IndexdedDbOnlyError::VersionTooOld => Error::VersionTooOld,
-            IndexdedDbOnlyError::InvalidCall => Error::InvalidCall,
-            IndexdedDbOnlyError::InvalidArgument => Error::InvalidArgument,
-            IndexdedDbOnlyError::AlreadyExists => Error::AlreadyExists,
-            IndexdedDbOnlyError::DoesNotExist => Error::DoesNotExist,
-            IndexdedDbOnlyError::DatabaseIsClosed => Error::DatabaseIsClosed,
-            IndexdedDbOnlyError::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
-            IndexdedDbOnlyError::ReadOnly => Error::ReadOnly,
-            IndexdedDbOnlyError::FailedClone => Error::FailedClone,
-            IndexdedDbOnlyError::InvalidRange => Error::InvalidRange,
-            IndexdedDbOnlyError::CursorCompleted => Error::CursorCompleted,
-        }
-    }
-}
+// impl<Err> From<IndexdedDbOnlyError> for Error<Err> {
+//     fn from(value: IndexdedDbOnlyError) -> Self {
+//         match value {
+//             IndexdedDbOnlyError::NotInBrowser => Error::NotInBrowser,
+//             IndexdedDbOnlyError::IndexedDbDisabled => Error::IndexedDbDisabled,
+//             IndexdedDbOnlyError::OperationNotSupported => Error::OperationNotSupported,
+//             IndexdedDbOnlyError::OperationNotAllowed => Error::OperationNotAllowed,
+//             IndexdedDbOnlyError::InvalidKey => Error::InvalidKey,
+//             IndexdedDbOnlyError::VersionMustNotBeZero => Error::VersionMustNotBeZero,
+//             IndexdedDbOnlyError::VersionTooOld => Error::VersionTooOld,
+//             IndexdedDbOnlyError::InvalidCall => Error::InvalidCall,
+//             IndexdedDbOnlyError::InvalidArgument => Error::InvalidArgument,
+//             IndexdedDbOnlyError::AlreadyExists => Error::AlreadyExists,
+//             IndexdedDbOnlyError::DoesNotExist => Error::DoesNotExist,
+//             IndexdedDbOnlyError::DatabaseIsClosed => Error::DatabaseIsClosed,
+//             IndexdedDbOnlyError::ObjectStoreWasRemoved => Error::ObjectStoreWasRemoved,
+//             IndexdedDbOnlyError::ReadOnly => Error::ReadOnly,
+//             IndexdedDbOnlyError::FailedClone => Error::FailedClone,
+//             IndexdedDbOnlyError::InvalidRange => Error::InvalidRange,
+//             IndexdedDbOnlyError::CursorCompleted => Error::CursorCompleted,
+//         }
+//     }
+// }

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,7 +6,7 @@ use crate::{
     CursorBuilder,
 };
 use futures_util::future::{Either, FutureExt};
-use std::{convert::Infallible, future::Future, ops::RangeBounds};
+use std::{future::Future, ops::RangeBounds};
 use web_sys::{wasm_bindgen::JsValue, IdbIndex};
 
 #[cfg(doc)]
@@ -32,7 +32,7 @@ impl Index {
     /// Checks whether the provided key (for this index) already exists
     ///
     /// Internally, this uses [`IDBIndex::count`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/count).
-    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool, Infallible>> {
+    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool>> {
         match self.sys.count_with_key(key) {
             Ok(count_req) => Either::Right(
                 transaction_request(count_req)
@@ -48,7 +48,7 @@ impl Index {
     pub fn count_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<usize, Infallible>> {
+    ) -> impl Future<Output = crate::Result<usize>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -65,7 +65,7 @@ impl Index {
     /// Get the object with key `key` for this index
     ///
     /// Internally, this uses [`IDBIndex::get`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/get).
-    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         match self.sys.get(key) {
             Ok(get_req) => Either::Right(
                 transaction_request(get_req)
@@ -83,7 +83,7 @@ impl Index {
     pub fn get_first_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -103,7 +103,7 @@ impl Index {
     pub fn get_all(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let get_req = match limit {
             None => self.sys.get_all(),
             Some(limit) => self
@@ -126,7 +126,7 @@ impl Index {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -149,7 +149,7 @@ impl Index {
     pub fn get_first_key_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -169,7 +169,7 @@ impl Index {
     pub fn get_all_keys(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let get_req = match limit {
             None => self.sys.get_all_keys(),
             Some(limit) => self
@@ -192,7 +192,7 @@ impl Index {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,7 +6,7 @@ use crate::{
     CursorBuilder,
 };
 use futures_util::future::{Either, FutureExt};
-use std::{future::Future, marker::PhantomData, ops::RangeBounds};
+use std::{convert::Infallible, future::Future, ops::RangeBounds};
 use web_sys::{wasm_bindgen::JsValue, IdbIndex};
 
 #[cfg(doc)]
@@ -18,23 +18,21 @@ use crate::Cursor;
 /// Most of the functions here take a [`JsValue`] as the key(s) to use in the index. If the index was
 /// built with a compound key, then you should use eg. `js_sys::Array::from_iter([key_1, key_2])` as
 /// the key.
-pub struct Index<Err> {
+pub struct Index {
     sys: IdbIndex,
-    _phantom: PhantomData<Err>,
 }
 
-impl<Err> Index<Err> {
-    pub(crate) fn from_sys(sys: IdbIndex) -> Index<Err> {
+impl Index {
+    pub(crate) fn from_sys(sys: IdbIndex) -> Index {
         Index {
             sys,
-            _phantom: PhantomData,
         }
     }
 
     /// Checks whether the provided key (for this index) already exists
     ///
     /// Internally, this uses [`IDBIndex::count`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/count).
-    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool, Err>> {
+    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool, Infallible>> {
         match self.sys.count_with_key(key) {
             Ok(count_req) => Either::Right(
                 transaction_request(count_req)
@@ -50,7 +48,7 @@ impl<Err> Index<Err> {
     pub fn count_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<usize, Err>> {
+    ) -> impl Future<Output = crate::Result<usize, Infallible>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -67,7 +65,7 @@ impl<Err> Index<Err> {
     /// Get the object with key `key` for this index
     ///
     /// Internally, this uses [`IDBIndex::get`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/get).
-    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>, Err>> {
+    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
         match self.sys.get(key) {
             Ok(get_req) => Either::Right(
                 transaction_request(get_req)
@@ -85,7 +83,7 @@ impl<Err> Index<Err> {
     pub fn get_first_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -105,7 +103,7 @@ impl<Err> Index<Err> {
     pub fn get_all(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
         let get_req = match limit {
             None => self.sys.get_all(),
             Some(limit) => self
@@ -128,7 +126,7 @@ impl<Err> Index<Err> {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -151,7 +149,7 @@ impl<Err> Index<Err> {
     pub fn get_first_key_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -171,7 +169,7 @@ impl<Err> Index<Err> {
     pub fn get_all_keys(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
         let get_req = match limit {
             None => self.sys.get_all_keys(),
             Some(limit) => self
@@ -194,7 +192,7 @@ impl<Err> Index<Err> {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Err>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -212,7 +210,7 @@ impl<Err> Index<Err> {
     }
 
     /// Open a [`Cursor`] on this index
-    pub fn cursor(&self) -> CursorBuilder<Err> {
+    pub fn cursor(&self) -> CursorBuilder {
         CursorBuilder::from_index(self.sys.clone())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod utils;
 
 pub use cursor::{Cursor, CursorBuilder, CursorDirection};
 pub use database::Database;
-pub use error::{Error, Result};
+pub use error::{Error, CallbackError, Result};
 pub use factory::{Factory, ObjectStoreBuilder, VersionChangeEvent};
 pub use index::Index;
 pub use object_store::{IndexBuilder, ObjectStore};

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -7,7 +7,7 @@ use crate::{
     CursorBuilder, Index,
 };
 use futures_util::future::{Either, FutureExt};
-use std::{convert::Infallible, future::Future, ops::RangeBounds};
+use std::{future::Future, ops::RangeBounds};
 use web_sys::{js_sys::JsString, wasm_bindgen::JsValue, IdbIndexParameters, IdbObjectStore};
 
 #[cfg(doc)]
@@ -74,7 +74,7 @@ impl ObjectStore {
     /// Note that this method can only be called from within an `on_upgrade_needed` callback.
     ///
     /// Internally, this uses [`IDBObjectStore::deleteIndex`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/deleteIndex).
-    pub fn delete_index(&self, name: &str) -> crate::Result<(), Infallible> {
+    pub fn delete_index(&self, name: &str) -> crate::Result<()> {
         self.sys
             .delete_index(name)
             .map_err(|err| match error_name!(&err) {
@@ -89,7 +89,7 @@ impl ObjectStore {
     /// This will error if the key already existed.
     ///
     /// Internally, this uses [`IDBObjectStore::add`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/add).
-    pub fn add(&self, value: &JsValue) -> impl Future<Output = crate::Result<JsValue, Infallible>> {
+    pub fn add(&self, value: &JsValue) -> impl Future<Output = crate::Result<JsValue>> {
         match self.sys.add(value) {
             Ok(add_req) => {
                 Either::Left(transaction_request(add_req).map(|res| res.map_err(map_add_err)))
@@ -107,7 +107,7 @@ impl ObjectStore {
         &self,
         key: &JsValue,
         value: &JsValue,
-    ) -> impl Future<Output = crate::Result<(), Infallible>> {
+    ) -> impl Future<Output = crate::Result<()>> {
         match self.sys.add_with_key(value, key) {
             Ok(add_req) => Either::Left(
                 transaction_request(add_req).map(|res| res.map_err(map_add_err).map(|_| ())),
@@ -121,7 +121,7 @@ impl ObjectStore {
     /// This will overwrite the previous value if the key already existed.
     ///
     /// Internally, this uses [`IDBObjectStore::add`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/add).
-    pub fn put(&self, value: &JsValue) -> impl Future<Output = crate::Result<JsValue, Infallible>> {
+    pub fn put(&self, value: &JsValue) -> impl Future<Output = crate::Result<JsValue>> {
         match self.sys.put(value) {
             Ok(add_req) => {
                 Either::Left(transaction_request(add_req).map(|res| res.map_err(map_add_err)))
@@ -139,7 +139,7 @@ impl ObjectStore {
         &self,
         key: &JsValue,
         value: &JsValue,
-    ) -> impl Future<Output = crate::Result<(), Infallible>> {
+    ) -> impl Future<Output = crate::Result<()>> {
         match self.sys.put_with_key(value, key) {
             Ok(add_req) => Either::Left(
                 transaction_request(add_req).map(|res| res.map_err(map_add_err).map(|_| ())),
@@ -151,7 +151,7 @@ impl ObjectStore {
     /// Clear this object store
     ///
     /// Internally, this uses [`IDBObjectStore::clear`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/clear).
-    pub fn clear(&self) -> impl Future<Output = crate::Result<(), Infallible>> {
+    pub fn clear(&self) -> impl Future<Output = crate::Result<()>> {
         match self.sys.clear() {
             Ok(clear_req) => Either::Left(
                 transaction_request(clear_req).map(|res| res.map_err(map_clear_err).map(|_| ())),
@@ -163,7 +163,7 @@ impl ObjectStore {
     /// Count the number of objects in this store
     ///
     /// Internally, this uses [`IDBObjectStore::count`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/count).
-    pub fn count(&self) -> impl Future<Output = crate::Result<usize, Infallible>> {
+    pub fn count(&self) -> impl Future<Output = crate::Result<usize>> {
         match self.sys.count() {
             Ok(count_req) => Either::Left(
                 transaction_request(count_req)
@@ -176,7 +176,7 @@ impl ObjectStore {
     /// Checks whether the provided key exists in this object store
     ///
     /// Internally, this uses [`IDBObjectStore::count`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/count).
-    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool, Infallible>> {
+    pub fn contains(&self, key: &JsValue) -> impl Future<Output = crate::Result<bool>> {
         match self.sys.count_with_key(key) {
             Ok(count_req) => Either::Left(
                 transaction_request(count_req)
@@ -194,7 +194,7 @@ impl ObjectStore {
     pub fn count_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<usize, Infallible>> {
+    ) -> impl Future<Output = crate::Result<usize>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -213,7 +213,7 @@ impl ObjectStore {
     /// Unfortunately, the IndexedDb API does not indicate whether an object was actually deleted.
     ///
     /// Internally, this uses [`IDBObjectStore::delete`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/delete).
-    pub fn delete(&self, key: &JsValue) -> impl Future<Output = crate::Result<(), Infallible>> {
+    pub fn delete(&self, key: &JsValue) -> impl Future<Output = crate::Result<()>> {
         match self.sys.delete(key) {
             Ok(delete_req) => Either::Left(
                 transaction_request(delete_req).map(|res| res.map_err(map_delete_err).map(|_| ())),
@@ -231,7 +231,7 @@ impl ObjectStore {
     pub fn delete_range(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<(), Infallible>> {
+    ) -> impl Future<Output = crate::Result<()>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -247,7 +247,7 @@ impl ObjectStore {
     /// Get the object with key `key`
     ///
     /// Internally, this uses [`IDBObjectStore::get`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/get).
-    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    pub fn get(&self, key: &JsValue) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         match self.sys.get(key) {
             Ok(get_req) => Either::Right(
                 transaction_request(get_req)
@@ -265,7 +265,7 @@ impl ObjectStore {
     pub fn get_first_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -285,7 +285,7 @@ impl ObjectStore {
     pub fn get_all(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let get_req = match limit {
             None => self.sys.get_all(),
             Some(limit) => self
@@ -307,7 +307,7 @@ impl ObjectStore {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -330,7 +330,7 @@ impl ObjectStore {
     pub fn get_first_key_in(
         &self,
         range: impl RangeBounds<JsValue>,
-    ) -> impl Future<Output = crate::Result<Option<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Option<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -350,7 +350,7 @@ impl ObjectStore {
     pub fn get_all_keys(
         &self,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let get_req = match limit {
             None => self.sys.get_all_keys(),
             Some(limit) => self
@@ -372,7 +372,7 @@ impl ObjectStore {
         &self,
         range: impl RangeBounds<JsValue>,
         limit: Option<u32>,
-    ) -> impl Future<Output = crate::Result<Vec<JsValue>, Infallible>> {
+    ) -> impl Future<Output = crate::Result<Vec<JsValue>>> {
         let range = match make_key_range(range) {
             Ok(range) => range,
             Err(e) => return Either::Left(std::future::ready(Err(e))),
@@ -392,7 +392,7 @@ impl ObjectStore {
     /// Get the [`Index`] with the provided name
     ///
     /// Internally, this uses [`IDBObjectStore::index`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/index).
-    pub fn index(&self, name: &str) -> crate::Result<Index, Infallible> {
+    pub fn index(&self, name: &str) -> crate::Result<Index> {
         Ok(Index::from_sys(self.sys.index(name).map_err(
             |err| match error_name!(&err) {
                 Some("InvalidStateError") => crate::Error::ObjectStoreWasRemoved,
@@ -420,7 +420,7 @@ impl<'a> IndexBuilder<'a> {
     /// Create the index
     ///
     /// Internally, this uses [`IDBObjectStore::createIndex`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/createIndex).
-    pub fn create(self) -> crate::Result<(), Infallible> {
+    pub fn create(self) -> crate::Result<()> {
         self.store
             .create_index_with_str_sequence_and_optional_parameters(
                 self.name,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -96,8 +96,8 @@ impl TransactionBuilder {
     //   untested and unsupported code path.
     pub async fn run<Ret, Err>(
         self,
-        transaction: impl 'static + AsyncFnOnce(Transaction) -> crate::Result<Result<Ret, Err>>,
-    ) -> crate::Result<Result<Ret, Err>>
+        transaction: impl 'static + AsyncFnOnce(Transaction) -> Result<Ret, crate::CallbackError<Err>>,
+    ) -> Result<Ret, crate::CallbackError<Err>>
     where
         Ret: 'static,
         Err: 'static,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,7 +3,6 @@ use crate::{
     ObjectStore,
 };
 use futures_channel::oneshot;
-use std::convert::Infallible;
 use web_sys::{
     wasm_bindgen::{JsCast, JsValue},
     IdbDatabase, IdbRequest, IdbTransaction, IdbTransactionMode,
@@ -33,7 +32,7 @@ impl Transaction {
     /// Returns an [`ObjectStore`] that can be used to operate on data in this transaction
     ///
     /// Internally, this uses [`IDBTransaction::objectStore`](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/objectStore).
-    pub fn object_store(&self, name: &str) -> crate::Result<ObjectStore, Infallible> {
+    pub fn object_store(&self, name: &str) -> crate::Result<ObjectStore> {
         Ok(ObjectStore::from_sys(self.sys.object_store(name).map_err(
             |err| match error_name!(&err) {
                 Some("NotFoundError") => crate::Error::DoesNotExist,
@@ -97,8 +96,8 @@ impl TransactionBuilder {
     //   untested and unsupported code path.
     pub async fn run<Ret, Err>(
         self,
-        transaction: impl 'static + AsyncFnOnce(Transaction) -> crate::Result<Ret, Err>,
-    ) -> crate::Result<Ret, Err>
+        transaction: impl 'static + AsyncFnOnce(Transaction) -> crate::Result<Result<Ret, Err>>,
+    ) -> crate::Result<Result<Ret, Err>>
     where
         Ret: 'static,
         Err: 'static,

--- a/src/transaction/runner.rs
+++ b/src/transaction/runner.rs
@@ -35,8 +35,8 @@ pub struct RunnableTransaction {
 impl RunnableTransaction {
     pub fn new<R, E>(
         transaction: IdbTransaction,
-        transaction_contents: impl 'static + Future<Output = Result<R, E>>,
-        send_res_to: oneshot::Sender<Result<R, E>>,
+        transaction_contents: impl 'static + Future<Output = crate::Result<Result<R, E>>>,
+        send_res_to: oneshot::Sender<crate::Result<Result<R, E>>>,
         send_polled_forbidden_thing_to: oneshot::Sender<PolledForbiddenThing>,
     ) -> RunnableTransaction
     where
@@ -48,7 +48,7 @@ impl RunnableTransaction {
             inflight_requests: Cell::new(0),
             future: RefCell::new(Box::pin(async move {
                 let result = transaction_contents.await;
-                if result.is_err() {
+                if matches!(result, Err(_) | Ok(Err(_))) {
                     // The transaction failed. We should abort it.
                     let _ = transaction.abort();
                 }

--- a/src/transaction/runner.rs
+++ b/src/transaction/runner.rs
@@ -35,8 +35,8 @@ pub struct RunnableTransaction {
 impl RunnableTransaction {
     pub fn new<R, E>(
         transaction: IdbTransaction,
-        transaction_contents: impl 'static + Future<Output = crate::Result<Result<R, E>>>,
-        send_res_to: oneshot::Sender<crate::Result<Result<R, E>>>,
+        transaction_contents: impl 'static + Future<Output = Result<R, E>>,
+        send_res_to: oneshot::Sender<Result<R, E>>,
         send_polled_forbidden_thing_to: oneshot::Sender<PolledForbiddenThing>,
     ) -> RunnableTransaction
     where
@@ -48,7 +48,7 @@ impl RunnableTransaction {
             inflight_requests: Cell::new(0),
             future: RefCell::new(Box::pin(async move {
                 let result = transaction_contents.await;
-                if matches!(result, Err(_) | Ok(Err(_))) {
+                if result.is_err() {
                     // The transaction failed. We should abort it.
                     let _ = transaction.abort();
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,7 +64,7 @@ pub(crate) fn err_from_event(evt: web_sys::Event) -> DomException {
         .expect("IDBRequest::error did not return a DOMException")
 }
 
-pub(crate) fn map_add_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_add_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("ReadOnlyError") => crate::Error::ReadOnly,
         Some("TransactionInactiveError") => {
@@ -78,7 +78,7 @@ pub(crate) fn map_add_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_clear_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_clear_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("ReadOnlyError") => crate::Error::ReadOnly,
         Some("TransactionInactiveError") => {
@@ -99,7 +99,7 @@ pub(crate) fn map_count_res(res: JsValue) -> usize {
     num.value_of() as usize
 }
 
-pub(crate) fn map_count_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_count_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::ObjectStoreWasRemoved,
         Some("TransactionInactiveError") => {
@@ -110,7 +110,7 @@ pub(crate) fn map_count_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_delete_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_delete_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("ReadOnlyError") => crate::Error::ReadOnly,
         Some("InvalidStateError") => crate::Error::ObjectStoreWasRemoved,
@@ -122,7 +122,7 @@ pub(crate) fn map_delete_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_get_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_get_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::ObjectStoreWasRemoved,
         Some("TransactionInactiveError") => {
@@ -133,7 +133,7 @@ pub(crate) fn map_get_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_open_cursor_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_open_cursor_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::ObjectStoreWasRemoved,
         Some("TransactionInactiveError") => {
@@ -144,7 +144,7 @@ pub(crate) fn map_open_cursor_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_cursor_advance_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_cursor_advance_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::CursorCompleted,
         Some("TransactionInactiveError") => {
@@ -155,7 +155,7 @@ pub(crate) fn map_cursor_advance_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_cursor_advance_until_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_cursor_advance_until_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::CursorCompleted,
         Some("TransactionInactiveError") => {
@@ -166,7 +166,7 @@ pub(crate) fn map_cursor_advance_until_err<Err>(err: JsValue) -> crate::Error<Er
     }
 }
 
-pub(crate) fn map_cursor_advance_until_primary_key_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_cursor_advance_until_primary_key_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::CursorCompleted,
         Some("TransactionInactiveError") => {
@@ -178,7 +178,7 @@ pub(crate) fn map_cursor_advance_until_primary_key_err<Err>(err: JsValue) -> cra
     }
 }
 
-pub(crate) fn map_cursor_delete_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_cursor_delete_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::CursorCompleted,
         Some("TransactionInactiveError") => {
@@ -189,7 +189,7 @@ pub(crate) fn map_cursor_delete_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn map_cursor_update_err<Err>(err: JsValue) -> crate::Error<Err> {
+pub(crate) fn map_cursor_update_err(err: JsValue) -> crate::Error {
     match error_name!(&err) {
         Some("InvalidStateError") => crate::Error::CursorCompleted,
         Some("TransactionInactiveError") => {
@@ -202,7 +202,7 @@ pub(crate) fn map_cursor_update_err<Err>(err: JsValue) -> crate::Error<Err> {
     }
 }
 
-pub(crate) fn make_key_range<Err>(range: impl RangeBounds<JsValue>) -> crate::Result<JsValue, Err> {
+pub(crate) fn make_key_range(range: impl RangeBounds<JsValue>) -> crate::Result<JsValue> {
     match (range.start_bound(), range.end_bound()) {
         (Bound::Unbounded, Bound::Unbounded) => return Err(crate::Error::InvalidRange),
         (Bound::Unbounded, Bound::Included(b)) => IdbKeyRange::upper_bound_with_open(b, false),


### PR DESCRIPTION
Even after https://github.com/Ekleog/indexed-db/commit/b3380b04a019f5791d8ce76b5c9a7720a5be2feb, `VersionChangeEvent<Err>` stills carries a generic over `Err` due to `Transaction<Err>`

With this PR I tried mutliple way of removing this.


## First commit

First commit just remove the `Err` from everywhere, that is straightforward, but obviously introduce errors (otherwise the Erro wouldn't be there in the first place :smile: )

## Second commit

Second commit showcase two non-working approaches at fixing the errors:

For instance this code:

```rust
    let db = factory
        .open::<()>("bar", 2, async move |evt| {
            evt.delete_object_store("things")?;  // Error ! `?` couldn't convert the error to `indexed_db::Error<()>`
            Ok(())
        })
        .await
        .unwrap();
```

The issue is that without parametrization `VersionChangeEvent::delete_object_store` returns a `indexed_db::Error<Infailible>` while `Factor::open` expects the callback to return a `indexed_db::Error<()>`

From there I tried two things (both failed 😆 ):
- Implement a `impl<Err> From<indexed_db::Error<Infailible>> for indexed_db::Error<Err>` however it doesn't work since Rust complains it is conflicting with `impl<T> From<T> for T` :/
- Introduce a dedicated type `indexed_db::IndexedDbOnlyError` (that is equivalent to `indexed_db::Error` but without the `User` possibility), and implement a `impl<Err> indexed_db::IndexedDbOnlyError for indexed_db::Error<Err>`. But here again Rust complains it is in conflict with the `User(#[from] Err)` of `indexed_db::Error` (since if `Err = indexed_db::IndexedDbOnlyError`, `#[from] Err` will produce another `impl From<indexed_db::IndexedDbOnlyError> for indexed_db::Error<>`

I have to say it kind of reinforce my opinion that embedding end-user error type in the library error type brings complexity for no real benefit (as a user [I had to fight against it quiet a bit](https://github.com/Scille/parsec-cloud/blob/bd50626d39374c2e57692756bc821acc7dabd0ca/libparsec/crates/platform_storage/src/web/utils.rs#L188-L233))

## Third commit

Third commit is an attempt at removing the `Error::User` and to replace it with a simpler `Result<Result<R, E>, indexed_db::Error>`.
It works and the implementation is simple, however it is not very convenient for the end user:
- User-error must be passed as `Ok(Err(MyError))` which feel weird :/
- While `?` can be used on errors from indexed_db (e.g. `t.object_store("data")?;`), it doesn't work for user-error. So instead the user has to rely on `if let Err(err) = my_function() { return Ok(Err(err)) }`


## Fourth commit

The last commit introduce splite the original `indexed_db::Error` into two:
- `indexed_db::Error` that contains only the indexed_db's specific errors (i.e. User has been removed)
- `indexed_db::CallbackError` that is simply 
```rust
/// Error type for all errors from this crate, plus a user-defined error.
#[derive(Clone, Debug, thiserror::Error)]
pub enum CallbackError<E> {
    #[error(transparent)]
    IndexedDb(#[from] Error),
    #[error("User error: {0}")]
    User(E),
}
```

I find it to work pretty well:
- All functions except `Factory::open` & `Transaction::run` return an `indexed_db::Error` without any parametrization \o/
- `?` can still be used directly in callbacks for errors from indexed_db (e.g. `t.object_store("data")?;`)
- user error has to be wrapped in `indexed_db::CallbackError::User` which only slighly more verbose (e.g. `rx.await.context("awaiting for something external").map_err(indexed_db::CallbackError::User)?;`)

So in the end I really like this last approach ;-)

What do you think ?